### PR TITLE
Remove shared libraries for s390x

### DIFF
--- a/ovirt-engine-wildfly.spec.in
+++ b/ovirt-engine-wildfly.spec.in
@@ -37,6 +37,7 @@ function remove_shared_objects () {
 }
 remove_shared_objects solaris-x86_64
 remove_shared_objects solaris-sparcv9
+remove_shared_objects linux-s390x
 %ifarch x86_64
 remove_shared_objects linux-i686
 %endif


### PR DESCRIPTION
Remove shared libraries for s390s platform, which we are not building
for in oVirt.

Signed-off-by: Martin Perina <mperina@redhat.com>
