### PR TITLE
Add rpmdevtools into BuildRequires

### DIFF
--- a/ovirt-engine-wildfly-overlay.spec.in
+++ b/ovirt-engine-wildfly-overlay.spec.in
@@ -8,6 +8,9 @@ URL:		http://www.ovirt.org
 BuildArch:	noarch
 Source0:	README.md
 
+# Required to assemble artifacts
+BuildRequires: rpmdevtools
+
 Requires:	ovirt-engine-wildfly = %{version}-%{release}
 
 


### PR DESCRIPTION
spectool is required to download source files to build
ovirt-engine-wildfly-overlay, so adding it to BuildRequires will make it
available in oVirt buildcontainer and we will not need it to install
manually for each build.

Signed-off-by: Martin Perina <mperina@redhat.com>
