### PR TITLE
Fix COPR build

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -7,4 +7,4 @@ installdeps:
 
 srpm: installdeps
 	.automation/build-srpm.sh
-	find . -name '*.src.rpm' -exec cp {} $(outdir) \;
+	find . -name $(shell sh -c "basename '$(spec)'|cut -f1 -d.")'*.src.rpm' -exec cp {} $(outdir) \;


### PR DESCRIPTION
Fix COPR build issue due to which ovirt-engine-widfly-overlay wasn't
built on COPR.

Signed-off-by: Martin Perina <mperina@redhat.com>
