### PR TITLE
copr: build correct srpm and add git suffix

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -16,5 +16,11 @@ ARTIFACTS_DIR=${1:-exported-artifacts}
 
 
 # Build SRPMs
-source $(dirname "$(readlink -f "$0")")/build-wildfly.sh
-source $(dirname "$(readlink -f "$0")")/build-wildfly-overlay.sh
+if [ "$1" = "ovirt-engine-wildfly" ]; then
+    source $(dirname "$(readlink -f "$0")")/build-wildfly.sh
+elif [ "$1" = "ovirt-engine-wildfly-overlay" ]; then
+    source $(dirname "$(readlink -f "$0")")/build-wildfly-overlay.sh
+else
+    source $(dirname "$(readlink -f "$0")")/build-wildfly.sh
+    source $(dirname "$(readlink -f "$0")")/build-wildfly-overlay.sh
+fi

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -3,8 +3,11 @@
 #       using for selecting the right src.rpm to be copied.
 
 installdeps:
-	dnf -y install coreutils curl dnf-utils findutils git rpmdevtools sed
+	dnf -y install coreutils curl dnf-utils git rpmdevtools sed
 
 srpm: installdeps
-	.automation/build-srpm.sh
-	find . -name $(shell sh -c "basename '$(spec)'|cut -f1 -d.")'*.src.rpm' -exec cp {} $(outdir) \;
+	$(eval SUFFIX=$(shell sh -c " echo '.master.$$(date -u +%Y%m%d)'"))
+	sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-engine-wildfly.spec.in
+	sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-engine-wildfly-overlay.spec.in
+	.automation/build-srpm.sh $(shell sh -c "basename '$(spec)'|cut -f1 -d.")
+	cp rpmbuild/SRPMS/*.src.rpm $(outdir)

--- a/ovirt-engine-wildfly-overlay.spec.in
+++ b/ovirt-engine-wildfly-overlay.spec.in
@@ -1,6 +1,6 @@
 Name:		ovirt-engine-wildfly-overlay
 Version:	@VERSION@
-Release:	@RELEASE@%{?dist}
+Release:	@RELEASE@%{?release_suffix}%{?dist}
 Summary:	WildFly overlay for ovirt-engine
 Group:		Virtualization/Management
 License:	ASL-2.0

--- a/ovirt-engine-wildfly.spec.in
+++ b/ovirt-engine-wildfly.spec.in
@@ -2,7 +2,7 @@
 
 Name:		ovirt-engine-wildfly
 Version:	@VERSION@
-Release:	@RELEASE@%{?dist}
+Release:	@RELEASE@%{?release_suffix}%{?dist}
 Summary:	WildFly Application Server for oVirt Engine
 Group:		Virtualization/Management
 License:	ASL 2.0


### PR DESCRIPTION
- Add a git suffix for COPR builds
- Only build the relevant srpm package.

This package builds 2 rpm's:
- ovirt-engine-wildfly
- ovirt-engine-wildfly-overlay

To make sure the correct one is build, we pass the spec that needs to be build via COPR and then call the correct build script.